### PR TITLE
Addressing a number of issues (ExamTime/ExamTime#12273)

### DIFF
--- a/lib/cohort_me.rb
+++ b/lib/cohort_me.rb
@@ -49,9 +49,7 @@ module CohortMe
 
     data = activity_class.where("#{activity_date_field} > ?", start_from).select(select_sql).joins("JOIN (" + cohort_query.to_sql + ") AS cohorts ON #{activity_table_name}.#{activity_user_id} = cohorts.#{activation_user_id}")
 
-    unique_data = data.all
-
-    analysis = unique_data.group_by{|d| convert_to_cohort_date(Time.parse(d.cohort_date.to_s), interval_name)}
+    analysis = data.all.group_by{|d| convert_to_cohort_date(Time.parse(d.cohort_date.to_s), interval_name)}
     cohort_hash =  Hash[analysis.sort_by { |cohort, data| cohort }]
 
     table = {}

--- a/lib/cohort_me.rb
+++ b/lib/cohort_me.rb
@@ -49,7 +49,7 @@ module CohortMe
       raise "database not supported"
     end
 
-    data = activity_class.where("created_at > ?", start_from).select(select_sql).joins("JOIN (" + cohort_query.to_sql + ") AS cohorts ON #{activity_table_name}.#{activity_user_id} = cohorts.#{activation_user_id}")
+    data = activity_class.where("#{activity_date_field} > ?", start_from).select(select_sql).joins("JOIN (" + cohort_query.to_sql + ") AS cohorts ON #{activity_table_name}.#{activity_user_id} = cohorts.#{activation_user_id}")
 
     unique_data = data.all.uniq{|d| [d.send(activity_user_id), d.cohort_date, d.periods_out] }
 


### PR DESCRIPTION
- Allow user to define the field on `:activity_class` that defines when the user was active.
- Switch to using `DATEDIFF` rather than `TIMEDIFF` which craps out at big intervals.
- Move the `DISTINCT` into the SQL query, so reducing memory requirements.
- Remove support for Postgres. Don't really need to support this, personally, so would rather remove it than leave something in place that is potentially broken.
